### PR TITLE
Temp ignore igoComplete when comparing JSONs

### DIFF
--- a/src/main/java/org/mskcc/smile/commons/impl/JsonComparatorImpl.java
+++ b/src/main/java/org/mskcc/smile/commons/impl/JsonComparatorImpl.java
@@ -40,6 +40,7 @@ public class JsonComparatorImpl implements JsonComparator {
         "patientAliases",
         "sampleAliases",
         "genePanel",
+        "igoComplete",
         "additionalProperties"};
 
     private final Map<String, String> STD_IGO_REQUEST_JSON_PROPS_MAP =


### PR DESCRIPTION
Temporarily ignoring igoComplete for sample json comparison until
backfilling of that property is completed

Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>
