### PR TITLE
Catch AssertionError when comparing JSONs

### DIFF
--- a/src/main/java/org/mskcc/smile/commons/impl/JsonComparatorImpl.java
+++ b/src/main/java/org/mskcc/smile/commons/impl/JsonComparatorImpl.java
@@ -184,6 +184,9 @@ public class JsonComparatorImpl implements JsonComparator {
             JSONAssert.assertEquals(referenceJson, targetJson, JSONCompareMode.STRICT);
         } catch (JSONException e) {
             return Boolean.FALSE;
+        } catch (AssertionError ae) {
+            System.out.println(ae.getLocalizedMessage());
+            return Boolean.FALSE;
         }
         return Boolean.TRUE;
     }

--- a/src/test/java/org/mskcc/smile/commons/JsonComparatorTest.java
+++ b/src/test/java/org/mskcc/smile/commons/JsonComparatorTest.java
@@ -44,11 +44,12 @@ public class JsonComparatorTest {
      * Simple test to assert failure when request ids are different.
      * @throws Exception
      */
-    @Test(expected = AssertionError.class)
+    @Test
     public void testConsistencyCheckFailure() throws Exception {
         String referenceJson = "{\"requestId\":\"mockRequestId\"}";
         String targetJson = "{\"requestId\":\"differentRequestId\"}";
-        jsonComparator.isConsistent(referenceJson, targetJson);
+        Boolean isConsistent = jsonComparator.isConsistent(referenceJson, targetJson);
+        Assert.assertFalse(isConsistent);
     }
 
     /**
@@ -100,7 +101,7 @@ public class JsonComparatorTest {
      * Test for handling of null fields in the published request json but not the incoming request json.
      * @throws Exception
      */
-    @Test(expected = AssertionError.class)
+    @Test
     public void testNullJsonFieldHandlingInPublishedRequest() throws Exception {
         MockJsonTestData incomingRequest =
                 mockedRequestJsonDataMap.get("mockIncomingRequest1JsonDataWith2T2N");


### PR DESCRIPTION
Signed-off-by: Angelica Ochoa <15623749+ao508@users.noreply.github.com>

# Catch AssertionError when comparing JSONs

Briefly describe changes proposed in this pull request:
- Add `AssertionError` as caught exception when comparing JSONs