### PR TITLE
Utilities to support distributed tracing context propagation via OpenTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,52 @@
 # SMILE Commons
 
 Centralized configurations for checkstyle plugin and dependency management. 
+
+## OpenTelemetryUtils
+
+This common library contains utilities to supoprt [Distributed Tracing](https://lightstep.com/opentelemetry/tracing) - [Context Propagation](https://lightstep.com/opentelemetry/context-propagation) via OpenTelemetry.
+
+### Basic Usage for application
+
+```java
+// required imports
+import org.mskcc.smile.commons.OpenTelemetryUtils;
+import org.mskcc.smile.commons.OpenTelemetryUtils.TraceMetadata;
+
+// inject
+@Autowired
+OpenTelemetryUtils openTelemetryUtils;
+
+// OpenTelemetry Tracer 
+private static final Tracer tracer = GlobalOpenTelemetry.get().getTracer("org.mskcc.cmo.Classname");
+
+// Upstream service propagating context to downstream service via a Nats Message
+Span testJetstreamPubSpan = tracer.spanBuilder("testJetStreamPubSpan").startSpan();
+Scope scope = testJetstreamPubSpan.makeCurrent();
+Span.current().addEvent("testJetstreamPubEvent: publishing to jetstream topic" + JETSTREAM_PUBLISH_TOPIC);
+TraceMetadata tmd = openTelemetryUtils.getTraceMetadata();
+messagingGateway.publishWithTrace(JETSTREAM_PUBLISH_TOPIC, "<this is test message body>", tmd);
+testJetstreamPubSpan.end();
+
+// Downstream service receiving context via onMessage subscription and continuing tracing using the same span
+@Override
+public void onMessage(Message msg, Object message)
+{
+    try {
+        // In production code, the following statement should check if TraceMetadata exists before usin it.
+        String traceId = msg.getHeaders().get(TraceMetadata.getHeaderKey()).get(0);
+        TraceMetadata tmd = new TraceMetadata(traceId);
+        Span testJetstreamSubOnMessageSpan = openTelemetryUtils.getSpan(tmd, "testJetStreamSubOnMessageSpan");
+
+        Scope scope = testJetstreamSubOnMessageSpan.makeCurrent();
+        String receivedMessageContent = new String(msg.getData(), StandardCharsets.UTF_8);
+        Attributes eventAttributes = Attributes.of(AttributeKey.stringKey("receivedMessageSubject"), msg.getSubject(),
+                                                   AttributeKey.stringKey("receivedMessageBody"), receivedMessageContent);
+        Span.current().addEvent("testJetstreamSubOnMessageEvent: messageReceived", eventAttributes);
+        testJetstreamSubOnMessageSpan.end();
+    }
+    catch (Exception e) {
+        System.out.println("Exception: " + e.getMessage());
+    }
+}
+```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.mskcc.cmo</groupId>
   <artifactId>smile-commons</artifactId>
   <name>CMO SMILE Commons</name>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <description>master maven module</description>
   <packaging>jar</packaging>
 
@@ -30,6 +30,18 @@
       <url>https://jitpack.io</url>
     </repository>
   </repositories>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.opentelemetry</groupId>
+        <artifactId>opentelemetry-bom</artifactId>
+        <version>1.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -71,13 +83,28 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>19.0</version>
+      <version>31.1-jre</version>
       <type>jar</type>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.18.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-context</artifactId>
+      <version>1.18.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.grpc</groupId>
+      <artifactId>grpc-core</artifactId>
+      <version>1.49.1</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/mskcc/smile/commons/OpenTelemetryUtils.java
+++ b/src/main/java/org/mskcc/smile/commons/OpenTelemetryUtils.java
@@ -1,0 +1,28 @@
+package org.mskcc.smile.commons;
+
+import io.opentelemetry.api.trace.Span;
+
+public interface OpenTelemetryUtils {
+
+    public class TraceMetadata {
+        private static final String TRACE_ID_HEADER_KEY = "traceparent";
+
+        private String traceMetadata;
+
+        public TraceMetadata(String md) {
+            traceMetadata = md;
+        }
+
+        public static String getHeaderKey() {
+            return TRACE_ID_HEADER_KEY;
+        }
+        
+        public String getMetadata() {
+            return traceMetadata;
+        }
+    }
+
+    TraceMetadata getTraceMetadata();
+    Span getSpan(TraceMetadata traceMetadata, String spanName);
+}
+

--- a/src/main/java/org/mskcc/smile/commons/impl/OpenTelemetryUtilsImpl.java
+++ b/src/main/java/org/mskcc/smile/commons/impl/OpenTelemetryUtilsImpl.java
@@ -1,0 +1,60 @@
+package org.mskcc.smile.commons.impl;
+
+import io.grpc.Metadata;
+import io.opentelemetry.api.GlobalOpenTelemetry;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.Tracer;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.propagation.TextMapGetter;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.context.propagation.TextMapSetter;
+import org.mskcc.smile.commons.OpenTelemetryUtils;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OpenTelemetryUtilsImpl implements OpenTelemetryUtils {
+
+    private static final TextMapPropagator textFormat =
+        GlobalOpenTelemetry.getPropagators().getTextMapPropagator();
+
+    private static final Tracer tracer =
+        GlobalOpenTelemetry.get().getTracer("org.mskcc.smile.commons.impl.OpenTelemetryImpl");
+
+    private static final TextMapGetter<Metadata> getter =
+        new TextMapGetter<Metadata>() {
+            @Override
+            public Iterable<String> keys(Metadata carrier) {
+                return carrier.keys();
+            }
+
+            @Override
+            public String get(Metadata carrier, String key) {
+                Metadata.Key<String> k = Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER);
+                if (carrier.containsKey(k)) {
+                    return carrier.get(k);
+                }
+                return "";
+            }
+        };
+
+    TextMapSetter<Metadata> setter =
+        (carrier, key, value) ->
+        carrier.put(Metadata.Key.of(key, Metadata.ASCII_STRING_MARSHALLER), value);
+
+    @Override
+    public TraceMetadata getTraceMetadata() {
+        Metadata headers = new Metadata();
+        textFormat.inject(Context.current(), headers, setter);
+        String traceId = getter.get(headers, TraceMetadata.getHeaderKey());
+        return new TraceMetadata(traceId);
+    }
+
+    @Override
+    public Span getSpan(TraceMetadata traceMetadata, String spanName) {
+        Metadata headers = new Metadata();
+        headers.put(Metadata.Key.of(TraceMetadata.getHeaderKey(),
+                                    Metadata.ASCII_STRING_MARSHALLER), traceMetadata.getMetadata());
+        Context extractedContext = textFormat.extract(Context.current(), headers, getter);
+        return tracer.spanBuilder(spanName).setParent(extractedContext).startSpan();
+    }
+}


### PR DESCRIPTION
A library around OpenTelemetry & gRPC libraries to provide [Distributed Tracing](https://lightstep.com/opentelemetry/tracing) - [Context Propagation](https://lightstep.com/opentelemetry/context-propagation) via OpenTelemetry using Nats messaging.

The included README is intended to show how to use these OpenTelemetryUtils to propagate a context via the Nats message, not how to use [OpenTelemetry for Java](https://opentelemetry.io/docs/instrumentation/java/).
