### PR TITLE
Update checkstyle to 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.1.1</version>
+        <version>3.6.0</version>
         <configuration>
           <configLocation>src/main/resources/checkstyle.xml</configLocation>
           <encoding>UTF-8</encoding>

--- a/src/main/resources/checkstyle.xml
+++ b/src/main/resources/checkstyle.xml
@@ -292,7 +292,7 @@
                       value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
-            <property name="scope" value="public"/>
+            <property name="accessModifiers" value="public"/>
             <property name="allowMissingParamTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="allowedAnnotations" value="Override, Test"/>


### PR DESCRIPTION
# Updated maven-checkstyle to 3.6.0

Briefly describe changes proposed in this pull request:
- updated checkstyle version to allow use of text blocks within `@Query` annotation for smile-server peristence layer

--- 
## Crossing T's and dotting I's

Please follow these checklists to help prevent any unexpected issues from being introduced by the changes in this pull request. If an item does not apply then indicate so by surrounding the line item with `~~` to strikethrough the text. See [basic writing and formatting syntax](https://docs.github.com/en/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax) for more information.

### Mocked request data and data model checklist:

**Data checks:** n/a

```
Updates were made to the mocked incoming request data and/or mocked published request data:
- [ ] [smile-server test data](https://github.com/mskcc/smile-server/tree/master/service/src/test/resources/data)
- [ ] [smile-commons test data](https://github.com/mskcc/smile-commons/tree/master/src/test/resources/data)
- [ ] [smile-label-generator test data](https://github.com/mskcc/smile-label-generator/tree/master/src/test/resources/data)
- [ ] [smile-request-filter test data](https://github.com/mskcc/smile-request-filter/tree/master/src/test/resources/data)
```

**Code checks:** n/a
```
- [ ] The JSON comparator code been updated to handle new changes.
- [ ] Unit tests were updated in relation to updates to the mocked test data.

If no unit tests were updated or added, then please explain why: [insert details here]
```
